### PR TITLE
Skip noqa comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,20 +23,19 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install Lint Requirements
+          command: pip install -r lint-requirements.txt
+      - run:
           name: flake8
           command: |
             pip install .
             flake8 flake8_spellcheck tests
       - run:
           name: isort
-          command: |
-            pip install isort
-            isort . --diff -c
+          command: isort . --diff -c
       - run:
           name: black
-          command: |
-            pip install black==19.3b0
-            black . --check
+          command: black . --check
       - run:
           name: check word dictionaries are sorted
           command: |
@@ -49,9 +48,7 @@ jobs:
             done
       - run:
           name: yamllint
-          command: |
-            pip install yamllint
-            yamllint .
+          command: yamllint .
   test-3.8:
     docker:
       - image: "python:3.7-stretch"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: isort
           command: |
             pip install isort
-            isort --diff -c
+            isort . --diff -c
       - run:
           name: black
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ test: &test
 jobs:
   lint:
     docker:
-      - image: "python:3.7-stretch"
+      - image: "python:3.8-stretch"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ test: &test
 jobs:
   lint:
     docker:
-      - image: "python:3.8-stretch"
+      - image: "python:3.8"
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Flake8 Spellcheck Changelog
 ===========================
 
+0.17.0
+------
+* Update technical.txt
+
 0.16.0
 ------
 * Add support for specifying spellcheck targets in flake8 configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Flake8 Spellcheck Changelog
 ===========================
 
+0.16.0
+------
+* Add support for specifying spellcheck targets in flake8 configuration
+
 0.15.0
 ------
 * Update technical and en_US

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Flake8 Spellcheck Changelog
 ===========================
 
+0.15.0
+------
+* Update technical and en_US
+
 0.14.0
 ------
 * Add "hardcode" to technical.txt

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,38 @@ Codes
 * SC100 - Spelling error in comments
 * SC200 - Spelling error in name (e.g. variable, function, class)
 
+Enable Django support
+---------------------
+
+You can enable support for a Django dictionary by adding the following to your
+flake8 configuration (e.g. your ``.flake8`` file):
+
+.. code-block:: ini
+
+    [flake8]
+    dictionaries=en_US,python,technical,django
+
+
+Specify Targets
+---------------
+
+Both ``comments`` and ``names`` (variable names, function names...) are spellchecked by default.
+You can specify what targets to spellcheck in your flake8 configuration (e.g. in your ``.flake8`` file):
+
+.. code-block:: ini
+
+   [flake8]
+   spellcheck-targets=comments
+
+The above configuration would only spellcheck comments
+
+.. code-block:: ini
+
+   [flake8]
+   spellcheck-targets=names
+
+The above configuration would only spellcheck names
+
 Contributing
 ------------
 
@@ -30,16 +62,6 @@ adding those word(s) to the appropriate dictionaries:
 * `technical dictionary <flake8_spellcheck/technical.txt>`_
 * `django dictionary <flake8_spellcheck/django.txt>`_
 
-Enable Django support
----------------------
-
-You can enable support for a Django dictionary by adding the following to your
-flake8 configuration (e.g. your ``.flake8`` file):
-
-.. code-block:: ini
-
-    [flake8]
-    dictionaries=en_US,python,technical,django
 
 .. |CircleCI| image:: https://circleci.com/gh/MichaelAquilina/flake8-spellcheck.svg?style=svg
    :target: https://circleci.com/gh/MichaelAquilina/flake8-spellcheck

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ The above configuration would only spellcheck names
 Contributing
 ------------
 
-If you have found word(s) which is listed as a spelling error but is actually a correct term used
+If you have found word(s) which are listed as a spelling error but are actually correct terms used
 in python or in technical implementations (e.g. http), then you can very easily contribute by
 adding those word(s) to the appropriate dictionaries:
 

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -79,7 +79,7 @@ def get_code(token_type):
 
 class SpellCheckPlugin:
     name = "flake8-spellcheck"
-    version = "0.14.0"
+    version = "0.15.0"
 
     def __init__(self, tree, filename="(none)", file_tokens=None):
         self.file_tokens = file_tokens

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -166,6 +166,8 @@ class SpellCheckPlugin:
         elif (
             token_info.type == tokenize.COMMENT
             and "comments" in self.spellcheck_targets
+            # ignore flake8 pragma comments
+            and token_info.string.lstrip("#").split()[0] != "noqa:"
         ):
             value = token_info.string.lstrip("#")
         else:

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -79,7 +79,7 @@ def get_code(token_type):
 
 class SpellCheckPlugin:
     name = "flake8-spellcheck"
-    version = "0.15.0"
+    version = "0.16.0"
 
     def __init__(self, tree, filename="(none)", file_tokens=None):
         self.file_tokens = file_tokens

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -122,11 +122,19 @@ class SpellCheckPlugin:
             comma_separated_list=True,
             parse_from_config=True,
         )
+        parser.add_option(
+            "--spellcheck-targets",
+            help="Specify the targets to spellcheck",
+            default="names,comments",
+            comma_separated_list=True,
+            parse_from_config=True,
+        )
 
     @classmethod
     def parse_options(cls, options):
         cls.whitelist_path = options.whitelist
         cls.dictionaries = [d + ".txt" for d in options.dictionaries]
+        cls.spellcheck_targets = set(options.spellcheck_targets)
 
     def _detect_errors(self, tokens, use_symbols, token_type):
         code = get_code(token_type)
@@ -153,9 +161,12 @@ class SpellCheckPlugin:
             yield from self._parse_token(token_info)
 
     def _parse_token(self, token_info):
-        if token_info.type == tokenize.NAME:
+        if token_info.type == tokenize.NAME and "names" in self.spellcheck_targets:
             value = token_info.string
-        elif token_info.type == tokenize.COMMENT:
+        elif (
+            token_info.type == tokenize.COMMENT
+            and "comments" in self.spellcheck_targets
+        ):
             value = token_info.string.lstrip("#")
         else:
             return

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -79,7 +79,7 @@ def get_code(token_type):
 
 class SpellCheckPlugin:
     name = "flake8-spellcheck"
-    version = "0.16.0"
+    version = "0.17.0"
 
     def __init__(self, tree, filename="(none)", file_tokens=None):
         self.file_tokens = file_tokens

--- a/flake8_spellcheck/technical.txt
+++ b/flake8_spellcheck/technical.txt
@@ -38,6 +38,7 @@ mysql
 namespace
 oauth2
 p4
+parallelize
 passwd
 perforce
 pid

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,0 +1,4 @@
+flake8==3.8.1
+isort==5.3.2
+black==19.3b0
+yamllint==1.24.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,3 @@ include_trailing_comma=true
 known_tests=tests
 combine_as_imports=true
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER,TESTS
-not_skip=__init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import setuptools
+
 from flake8_spellcheck import SpellCheckPlugin
 
 requires = ["flake8 > 3.0.0"]

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+
 from flake8_spellcheck import is_number, parse_camel_case, parse_snake_case
 
 

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -92,6 +92,11 @@ class TestComments:
         assert result.exit_code == 0
         assert result.out_lines == []
 
+    def test_flake8_pragma(self, flake8dir):
+        flake8dir.make_example_py("foo = 'bar'  # noqa: W503")
+        result = flake8dir.run_flake8()
+        assert result.out_lines == []
+
 
 class TestFunctionDef:
     def test_apostrophe(self, flake8dir):

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -80,6 +80,17 @@ class TestComments:
         result = flake8dir.run_flake8()
         assert result.out_lines == []
 
+    def test_disabled(self, flake8dir):
+        flake8dir.make_example_py(
+            """
+            # dont "make" b4d c8omm3nts
+            foo = "bar"
+        """
+        )
+        result = flake8dir.run_flake8(["--spellcheck-targets=names"])
+        assert result.exit_code == 0
+        assert result.out_lines == []
+
 
 class TestFunctionDef:
     def test_apostrophe(self, flake8dir):
@@ -134,6 +145,17 @@ class TestFunctionDef:
         assert result.exit_code == 0
         assert result.out_lines == []
 
+    def test_disabled(self, flake8dir):
+        flake8dir.make_example_py(
+            """
+            def mispleled_function(a, b, c):
+                pass
+        """
+        )
+        result = flake8dir.run_flake8(["--spellcheck-targets=comments"])
+        assert result.exit_code == 0
+        assert result.out_lines == []
+
 
 class TestName:
     def test_fail(self, flake8dir):
@@ -165,6 +187,18 @@ class TestName:
         assert result.exit_code == 0
         assert result.out_lines == []
 
+    def test_disabled(self, flake8dir):
+        flake8dir.make_example_py(
+            """
+            my_varaible_namde = "something"
+            SOMETHIGN = "SOMETHING"
+            SOMETHING_ELS = "SOMETHING"
+        """
+        )
+        result = flake8dir.run_flake8(["--spellcheck-targets=comments"])
+        assert result.exit_code == 0
+        assert result.out_lines == []
+
 
 class TestClassDef:
     def test_fail(self, flake8dir):
@@ -189,6 +223,17 @@ class TestClassDef:
         """
         )
         result = flake8dir.run_flake8()
+        assert result.out_lines == []
+
+    def test_disabled(self, flake8dir):
+        flake8dir.make_example_py(
+            """
+        class FackeClaessName:
+            pass
+        """
+        )
+        result = flake8dir.run_flake8(["--spellcheck-targets=comments"])
+        assert result.exit_code == 0
         assert result.out_lines == []
 
 


### PR DESCRIPTION
`noqa` comments allow skipping certain flake8 codes on a line. Unfortunately, both `noqa` and the flake8 codes are not recognized as words (because they aren't). This change skips checking comment lines that begin with `noqa: `