### PR TITLE
Fix broken isort command in lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: isort
           command: |
             pip install isort
-            isort --diff -c
+            isort . --diff -c
       - run:
           name: black
           command: |

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import setuptools
+
 from flake8_spellcheck import SpellCheckPlugin
 
 requires = ["flake8 > 3.0.0"]

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+
 from flake8_spellcheck import is_number, parse_camel_case, parse_snake_case
 
 


### PR DESCRIPTION
isort requires a directory to be passed to it. changing `isort [options]` to `isort . [options]` fixes the currently failing linter job.