### PR TITLE
 Skip noqa comments

### DIFF
--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -166,6 +166,8 @@ class SpellCheckPlugin:
         elif (
             token_info.type == tokenize.COMMENT
             and "comments" in self.spellcheck_targets
+            # ignore flake8 pragma comments
+            and token_info.string.lstrip("#").split()[0] != "noqa:"
         ):
             value = token_info.string.lstrip("#")
         else:

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -92,6 +92,18 @@ class TestComments:
         assert result.exit_code == 0
         assert result.out_lines == []
 
+    def test_flake8_pragma(self, flake8dir):
+        flake8dir.make_example_py("foo = 'bar'  # noqa: W503")
+        result = flake8dir.run_flake8()
+        assert result.out_lines == []
+
+    def test_flake8_pragma_spaces(self, flake8dir):
+        flake8dir.make_example_py("foo = 'bar'  #    noqa: W503")
+        result = flake8dir.run_flake8()
+        assert result.out_lines == [
+            "./example.py:1:14: E262 inline comment should start with '# '"
+        ]
+
 
 class TestFunctionDef:
     def test_apostrophe(self, flake8dir):


### PR DESCRIPTION
this is a retry of #29 with the changes squashed properly.

`noqa` comments allow skipping certain flake8 codes on a line. Unfortunately, both `noqa` and the flake8 codes are not recognized as words (because they aren't). This change skips checking comment lines that begin with `noqa: