### PR TITLE
Added abstractmethod from Python standard library abc

### DIFF
--- a/flake8_spellcheck/python.txt
+++ b/flake8_spellcheck/python.txt
@@ -1,4 +1,5 @@
 abspath
+abstractmethod
 arg
 argparse
 args


### PR DESCRIPTION
Not sure why my system removed and added the same line back in at the end. abstractmethod is a decorator in the library.