### PR TITLE
fix issue #36

### DIFF
--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -1,8 +1,11 @@
 import os
+import re
 import tokenize
 from string import ascii_lowercase, ascii_uppercase, digits
 
 import pkg_resources
+
+NOQA_REGEX = re.compile(r"#[\s]*noqa:[\s]*[\D]+[\d]+")
 
 
 # Really simple detection function
@@ -174,7 +177,9 @@ class SpellCheckPlugin:
         if token_info.type == tokenize.NAME and "names" in self.spellcheck_targets:
             value = token_info.string
         elif self._is_valid_comment(token_info):
-            value = token_info.string.lstrip("#")
+            # strip out all `noqa: [code]` style comments so they aren't erroneously checked
+            # see https://github.com/MichaelAquilina/flake8-spellcheck/issues/36 for info
+            value = NOQA_REGEX.sub("", token_info.string.lstrip("#"))
         else:
             return
 

--- a/flake8_spellcheck/python.txt
+++ b/flake8_spellcheck/python.txt
@@ -95,6 +95,7 @@ mypy
 namedtuple
 nargs
 netloc
+noqa
 optionxform
 optparse
 pkgutil

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -116,6 +116,17 @@ class TestComments:
         result = flake8dir.run_flake8()
         assert result.out_lines == []
 
+    # Regression test for https://github.com/MichaelAquilina/flake8-spellcheck/issues/36
+    def test_type_and_noqa(self, flake8dir):
+        flake8dir.make_example_py(
+            """
+            # the comment below should not fail on `W503` or `W504`  # noqa: SC100
+            foo = []  # type: ignore  # noqa: W503  # noqa: W504
+        """
+        )
+        result = flake8dir.run_flake8()
+        assert result.out_lines == []
+
 
 class TestFunctionDef:
     def test_apostrophe(self, flake8dir):


### PR DESCRIPTION
use a regex to remove all `noqa: [code]` sections of comments so they aren't spellchecked. all tests pass on my end, please let me know how it looks

closes #36 