### PR TITLE
Speed up plugin by ~5X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 build
 dist
 *.egg-info
+flake8_spellcheck/version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Flake8 Spellcheck Changelog
 ===========================
+0.24.0
+------
+* Speed up run for multiple files by loading once the dictionary, and using ``importlib.resources`` instead of
+  ``pkg_resources`` - by @gaborbernat.
 
 0.21.0 - 0.23.0
 ---------------

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -4,6 +4,8 @@ import sys
 import tokenize
 from string import ascii_lowercase, ascii_uppercase, digits
 
+from .version import version as __version__
+
 NOQA_REGEX = re.compile(r"#[\s]*noqa:[\s]*[\D]+[\d]+")
 
 if sys.version_info >= (3, 7):
@@ -86,7 +88,7 @@ def get_code(token_type):
 
 class SpellCheckPlugin:
     name = "flake8-spellcheck"
-    version = "0.23.0"
+    version = __version__
 
     def __init__(self, tree, filename="(none)", file_tokens=None):
         self.file_tokens = file_tokens
@@ -204,3 +206,6 @@ class SpellCheckPlugin:
 
         for error_tuple in self._detect_errors(tokens, use_symbols, token_info.type):
             yield error_tuple
+
+
+__all__ = ("__versions__", "SpellCheckPlugin")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools >= 44", "wheel >= 0.30", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "flake8_spellcheck/version.py"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 from flake8_spellcheck import SpellCheckPlugin
 
-requires = ["flake8 > 3.0.0"]
+requires = ["flake8 > 3.0.0", 'importlib-resources>=3.3;python_version<"3.7"']
 
 with open("README.rst") as fp:
     long_description = fp.read()

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 import setuptools
 
-from flake8_spellcheck import SpellCheckPlugin
-
-requires = ["flake8 > 3.0.0", 'importlib-resources>=3.3;python_version<"3.7"']
+requires = ["flake8 > 3.0.0", 'importlib-resources>=3;python_version<"3.7"']
 
 with open("README.rst") as fp:
     long_description = fp.read()
@@ -10,7 +8,6 @@ with open("README.rst") as fp:
 setuptools.setup(
     name="flake8-spellcheck",
     license="MIT",
-    version=SpellCheckPlugin.version,
     description="Spellcheck variables, comments and docstrings",
     long_description=long_description,
     author="Michael Aquilina",


### PR DESCRIPTION
On the [tox rewrite branch](https://github.com/tox-dev/tox/blob/rewrite/tox.ini#L61-L71) this took the flake8 runtime from 24.53 seconds to 4.92s.

- Load dictionary once and reuse (construct once, rather than for every file)
- Prefer the ``importlib.resources`` over pkg_resources (at least 100ms faster)
- the CI broke due to PEP-517 not being used, so fix that too.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
