### PR TITLE
Add Runtime so RuntimeError is accepted

### DIFF
--- a/flake8_spellcheck/python.txt
+++ b/flake8_spellcheck/python.txt
@@ -134,6 +134,7 @@ returncode
 rmtree
 rsplit
 rstrip
+runtime
 scandir
 setattr
 setdefault


### PR DESCRIPTION
I'm getting a spellcheck error on RuntimeError saying possible misspelt word "Runtime"
In the meantime I'm adding it to my whitelist.