### PR TITLE
add possibility to specify white list words in files comments

### DIFF
--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -203,7 +203,7 @@ class SpellCheckPlugin:
         local_words = set()
         for token_info in self.file_tokens:
             if (
-                token_info.type == tokenize.COMMENT 
+                token_info.type == tokenize.COMMENT
                 and token_info.string.lstrip("#").strip() != ""
                 and token_info.string.lstrip("#").split()[0] == "spellchecker:words"
             ):

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -194,14 +194,15 @@ class SpellCheckPlugin:
                 )
 
     def run(self) -> Iterator[LintError]:
-        self.local_words = self._get_local_words()
-        for token_info in self.file_tokens:
+        file_tokens = list(self.file_tokens)  # we need to copy the iterator in a list
+        self.local_words = self._get_local_words(file_tokens)
+        for token_info in file_tokens:
             yield from self._parse_token(token_info)
 
-    def _get_local_words(self) -> FrozenSet:
+    def _get_local_words(self, file_tokens: List[TokenInfo]) -> FrozenSet:
         """Get files listed after comments # spellchecker:words."""
         local_words = set()
-        for token_info in self.file_tokens:
+        for token_info in file_tokens:
             if (
                 token_info.type == tokenize.COMMENT
                 and token_info.string.lstrip("#").strip() != ""

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -197,7 +197,7 @@ class SpellCheckPlugin:
 
     def run(self) -> Iterator[LintError]:
         file_tokens = list(self.file_tokens)  # we need to copy the iterator in a list
-        # self.local_words = self._get_local_words(file_tokens)
+        self.local_words = self._get_local_words(file_tokens)
         for token_info in file_tokens:
             yield from self._parse_token(token_info)
 

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -194,7 +194,7 @@ class SpellCheckPlugin:
                 )
 
     def run(self) -> Iterator[LintError]:
-        self._get_local_words()
+        self.local_words = self._get_local_words()
         for token_info in self.file_tokens:
             yield from self._parse_token(token_info)
 
@@ -208,7 +208,7 @@ class SpellCheckPlugin:
                 and token_info.string.lstrip("#").split()[0] == "spellchecker:words"
             ):
                 local_words |= {w.lower() for w in token_info.string.lstrip("#").split()[1:]}
-        self.local_words = FrozenSet(local_words)
+        return FrozenSet(local_words)
 
     def _is_valid_comment(self, token_info: tokenize.TokenInfo) -> bool:
         return (

--- a/flake8_spellcheck/__init__.py
+++ b/flake8_spellcheck/__init__.py
@@ -180,9 +180,11 @@ class SpellCheckPlugin:
             test_token = token.lower().strip("'").strip('"')
 
             if use_symbols:
-                valid = (test_token in self.words) or (test_token in self.local_words)
+                # valid = (test_token in self.words) or (test_token in self.local_words)
+                valid = (test_token in self.words)
             else:
-                valid = (test_token in self.no_symbols) or (test_token in self.local_words)
+                # valid = (test_token in self.no_symbols) or (test_token in self.local_words)
+                valid = (test_token in self.no_symbols)
 
             # Need a way of matching words without symbols
             if not valid and not is_number(token):
@@ -195,7 +197,7 @@ class SpellCheckPlugin:
 
     def run(self) -> Iterator[LintError]:
         file_tokens = list(self.file_tokens)  # we need to copy the iterator in a list
-        self.local_words = self._get_local_words(file_tokens)
+        # self.local_words = self._get_local_words(file_tokens)
         for token_info in file_tokens:
             yield from self._parse_token(token_info)
 

--- a/tests/test_flake8_spellcheck.py
+++ b/tests/test_flake8_spellcheck.py
@@ -112,6 +112,19 @@ class TestComments:
             "./example.py:1:14: E262 inline comment should start with '# '"
         ]
 
+    def test_spellchecker_words_addition_comment(self, flake8_path):
+        (flake8_path / "example.py").write_text(
+            dedent(
+                """
+                # spellchecker:words notinwhitelistfile
+                #
+                # notinwhitelistfile
+                """
+            )
+        )
+        result = flake8_path.run_flake8()
+        assert result.out_lines == []
+
     # Regression test for github.com/MichaelAquilina/flake8-spellcheck/issues/34
     def test_empty_comment(self, flake8_path):
         (flake8_path / "example.py").write_text(


### PR DESCRIPTION
This adds the possibility to add words to the white list using comments in the python files
using the comment "# spellcheck:words" followed by a list of words to add.

The word added through the comments are used only when checking the file that contains these comments.

this addressed the issue https://github.com/MichaelAquilina/flake8-spellcheck/issues/83
